### PR TITLE
久々に？ Amazon で検索すると、広告除外が効かない問題

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -18,7 +18,7 @@
     {
       "matches": ["*://*.amazon.co.jp/s?*"],
       "js": ["src/contentScript.ts"],
-      "run_at": "document_start"
+      "run_at": "document_end"
     }
   ]
 }


### PR DESCRIPTION
なんでだろう？

- console に特にそれらしい情報は残っていない

![image](https://github.com/Cside/amazon-unsponsor/assets/315510/7e7f80a6-5477-40e7-b1e9-4679c22037da)

## 対策

- とりあえず document_start -> document_end にしてみる ...